### PR TITLE
fix: workflow image case

### DIFF
--- a/.github/workflows/build_linux_ubuntu1804.yml
+++ b/.github/workflows/build_linux_ubuntu1804.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         build_type: [release]
     container:
-      image: ghcr.io/${{ github.repository_owner }}/ten_building_ubuntu1804
+      image: ghcr.io/ten-framework/ten_building_ubuntu1804
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_linux_ubuntu1804.yml
+++ b/.github/workflows/build_linux_ubuntu1804.yml
@@ -11,7 +11,8 @@ on:
       - "docs/**"
       - ".vscode/**"
       - ".devcontainer/**"
-      - ".github/configs/**"
+      - ".github/**"
+      - "!.github/workflows/build_linux_ubuntu1804.yml"
       - "**.md"
   pull_request:
 

--- a/.github/workflows/build_linux_ubuntu2204.yml
+++ b/.github/workflows/build_linux_ubuntu2204.yml
@@ -23,7 +23,7 @@ jobs:
         compiler: [gcc, clang]
         build_type: [debug, release]
     container:
-      image: ghcr.io/${{ github.repository_owner }}/ten_building_ubuntu2204
+      image: ghcr.io/ten-framework/ten_building_ubuntu2204
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_linux_ubuntu2204.yml
+++ b/.github/workflows/build_linux_ubuntu2204.yml
@@ -11,7 +11,8 @@ on:
       - "docs/**"
       - ".vscode/**"
       - ".devcontainer/**"
-      - ".github/configs/**"
+      - ".github/**"
+      - "!.github/workflows/build_linux_ubuntu2204.yml"
       - "**.md"
   pull_request:
 


### PR DESCRIPTION
- image name requires lower case while the `TEN` is not, so use the fixed name instead 
- skip non-self workflow changes for the `.github` path