### PR TITLE
feat: add ci for mac and windows

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -1,4 +1,5 @@
 name: Build - mac
+
 on:
   push:
     branches:
@@ -26,13 +27,16 @@ jobs:
         with:
           fetch-depth: "0"
           submodules: "true"
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
+
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
           cache: false
+
       - name: Install tools and dependencies
         run: |
           brew install tree
@@ -41,6 +45,7 @@ jobs:
           go env -w GOFLAGS="-buildvcs=false"
           rustup default nightly
           cargo install --force cbindgen
+
       - name: Build
         run: |
           export PATH=$(pwd)/core/ten_gn:$PATH
@@ -59,13 +64,16 @@ jobs:
         with:
           fetch-depth: "0"
           submodules: "true"
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
+
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
           cache: false
+
       - name: Install tools and dependencies
         run: |
           brew install tree
@@ -74,6 +82,7 @@ jobs:
           go env -w GOFLAGS="-buildvcs=false"
           rustup default nightly
           cargo install --force cbindgen
+
       - name: Build
         run: |
           export PATH=$(pwd)/core/ten_gn:$PATH

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -1,0 +1,83 @@
+name: Build - mac
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+    paths-ignore:
+      - "tools/**"
+      - "docs/**"
+      - ".vscode/**"
+      - ".devcontainer/**"
+      - ".github/**"
+      - "!.github/workflows/build_mac.yml"
+      - "**.md"
+  pull_request:
+
+jobs:
+  build-arm64:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        build_type: [debug, release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          submodules: "true"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+      - name: Install tools and dependencies
+        run: |
+          brew install tree
+          pip3 install --use-pep517 python-dotenv jinja2
+          go install golang.org/dl/go1.20.12@latest && go1.20.12 download
+          go env -w GOFLAGS="-buildvcs=false"
+          rustup default nightly
+          cargo install --force cbindgen
+      - name: Build
+        run: |
+          export PATH=$(pwd)/core/ten_gn:$PATH
+          echo $PATH
+          tgn gen mac arm64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false ten_enable_go_binding=${{ matrix.build_type == 'debug' && 'false' || 'true' }} ten_enable_package_manager=${{ matrix.build_type == 'debug' && 'false' || 'true' }} enable_sanitizer=false
+          tgn build mac arm64 ${{ matrix.build_type }}
+          tree -I 'gen|obj' out
+
+  build-x64:
+    runs-on: macos-13
+    strategy:
+      matrix:
+        build_type: [debug, release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          submodules: "true"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+      - name: Install tools and dependencies
+        run: |
+          brew install tree
+          pip3 install --use-pep517 python-dotenv jinja2
+          go install golang.org/dl/go1.20.12@latest && go1.20.12 download
+          go env -w GOFLAGS="-buildvcs=false"
+          rustup default nightly
+          cargo install --force cbindgen
+      - name: Build
+        run: |
+          export PATH=$(pwd)/core/ten_gn:$PATH
+          echo $PATH
+          tgn gen mac x64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false ten_enable_go_binding=${{ matrix.build_type == 'debug' && 'false' || 'true' }} ten_enable_package_manager=${{ matrix.build_type == 'debug' && 'false' || 'true' }} enable_sanitizer=false
+          tgn build mac x64 ${{ matrix.build_type }}
+          tree -I 'gen|obj' out

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,4 +1,5 @@
 name: Build - win
+
 on:
   push:
     branches:
@@ -26,14 +27,18 @@ jobs:
         with:
           fetch-depth: "0"
           submodules: "true"
+
       - uses: ilammy/msvc-dev-cmd@v1
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
+
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
           cache: false
+
       - name: Install tools and dependencies
         run: |
           pip3 install --use-pep517 python-dotenv jinja2
@@ -41,6 +46,7 @@ jobs:
           go env -w GOFLAGS="-buildvcs=false"
           rustup default nightly
           cargo install --force cbindgen
+
       - name: Build
         run: |
           $ENV:PATH += ";$PWD/core/ten_gn"

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,0 +1,48 @@
+name: Build - win
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+    paths-ignore:
+      - "tools/**"
+      - "docs/**"
+      - ".vscode/**"
+      - ".devcontainer/**"
+      - ".github/**"
+      - "!.github/workflows/build_win.yml"
+      - "**.md"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        build_type: [debug, release]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          submodules: "true"
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+      - name: Install tools and dependencies
+        run: |
+          pip3 install --use-pep517 python-dotenv jinja2
+          go install golang.org/dl/go1.20.12@latest && go1.20.12 download
+          go env -w GOFLAGS="-buildvcs=false"
+          rustup default nightly
+          cargo install --force cbindgen
+      - name: Build
+        run: |
+          $ENV:PATH += ";$PWD/core/ten_gn"
+          tgn gen win x64 ${{ matrix.build_type }} -- vs_version=2022 log_level=1 enable_serialized_actions=true ten_enable_test=false
+          tgn build win x64 ${{ matrix.build_type }}


### PR DESCRIPTION
- build both `x64/arm64` and `debug/release` combinations for mac
  - `ten_package_manger/ten_enable_go_binding/enable_sanitizer` has been disabled for `debug` due to asan linking error, can be enabled once fixed 
- build windows `debug/release` via vs2022 