### PR TITLE
feat: improve mac ci

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -41,7 +41,10 @@ jobs:
         run: |
 
           if [ ${{ matrix.build_type }} == "debug" ]; then
-            # lock llvm and rust version to enable asan
+            # Since the TEN runtime and TEN manager are a combination of C and
+            # Rust, to enable ASan, the ASan versions used by both the C and
+            # Rust compilation environments must be consistent. Therefore, it is
+            # necessary to lock the LLVM and Rust versions to enable ASan.
             brew install llvm@18
             rustup default nightly-2024-07-19
           else
@@ -89,7 +92,10 @@ jobs:
         run: |
 
           if [ ${{ matrix.build_type }} == "debug" ]; then
-            # lock llvm and rust version to enable asan
+            # Since the TEN runtime and TEN manager are a combination of C and
+            # Rust, to enable ASan, the ASan versions used by both the C and
+            # Rust compilation environments must be consistent. Therefore, it is
+            # necessary to lock the LLVM and Rust versions to enable ASan.
             brew install llvm@18
             rustup default nightly-2024-07-19
           else

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        build_type: [debug, release]
+        build_type: [release]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -43,7 +43,6 @@ jobs:
           if [ ${{ matrix.build_type }} == "debug" ]; then
             # lock llvm and rust version to enable asan
             brew install llvm@18
-            export PATH="/opt/homebrew/opt/llvm@18/bin:$PATH"
             rustup default nightly-2024-07-19
           else
             rustup default nightly
@@ -57,6 +56,9 @@ jobs:
 
       - name: Build
         run: |
+          if [ ${{ matrix.build_type }} == "debug" ]; then
+            export PATH="/opt/homebrew/opt/llvm@18/bin:$PATH"
+          fi
           export PATH=$(pwd)/core/ten_gn:$PATH
           echo $PATH
           tgn gen mac arm64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false
@@ -88,7 +90,6 @@ jobs:
 
           if [ ${{ matrix.build_type }} == "debug" ]; then
             # lock llvm and rust version to enable asan
-            export PATH="/usr/local/opt/llvm@18/bin:$PATH"
             rustup default nightly-2024-07-19
           else
             rustup default nightly
@@ -102,6 +103,9 @@ jobs:
 
       - name: Build
         run: |
+          if [ ${{ matrix.build_type }} == "debug" ]; then
+            export PATH="/usr/local/opt/llvm@18/bin:$PATH"
+          fi
           export PATH=$(pwd)/core/ten_gn:$PATH
           echo $PATH
           tgn gen mac x64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -90,6 +90,7 @@ jobs:
 
           if [ ${{ matrix.build_type }} == "debug" ]; then
             # lock llvm and rust version to enable asan
+            brew install llvm@18
             rustup default nightly-2024-07-19
           else
             rustup default nightly

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -39,17 +39,24 @@ jobs:
 
       - name: Install tools and dependencies
         run: |
-          brew install llvm@18
+
+          if [ ${{ matrix.build_type }} == "debug" ]; then
+            # lock llvm and rust version to enable asan
+            brew install llvm@18
+            export PATH="/opt/homebrew/opt/llvm@18/bin:$PATH"
+            rustup default nightly-2024-07-19
+          else
+            rustup default nightly
+          fi
+
           brew install tree
           pip3 install --use-pep517 python-dotenv jinja2
           go install golang.org/dl/go1.20.12@latest && go1.20.12 download
           go env -w GOFLAGS="-buildvcs=false"
-          rustup default nightly-2024-07-19
           cargo install --force cbindgen
 
       - name: Build
         run: |
-          export PATH="/opt/homebrew/opt/llvm@18/bin:$PATH"
           export PATH=$(pwd)/core/ten_gn:$PATH
           echo $PATH
           tgn gen mac arm64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false
@@ -78,17 +85,23 @@ jobs:
 
       - name: Install tools and dependencies
         run: |
-          brew install llvm@18
+
+          if [ ${{ matrix.build_type }} == "debug" ]; then
+            # lock llvm and rust version to enable asan
+            export PATH="/usr/local/opt/llvm@18/bin:$PATH"
+            rustup default nightly-2024-07-19
+          else
+            rustup default nightly
+          fi
+
           brew install tree
           pip3 install --use-pep517 python-dotenv jinja2
           go install golang.org/dl/go1.20.12@latest && go1.20.12 download
           go env -w GOFLAGS="-buildvcs=false"
-          rustup default nightly-2024-07-19
           cargo install --force cbindgen
 
       - name: Build
         run: |
-          export PATH="/usr/local/opt/llvm@18/bin:$PATH"
           export PATH=$(pwd)/core/ten_gn:$PATH
           echo $PATH
           tgn gen mac x64 ${{ matrix.build_type }} -- log_level=1 enable_serialized_actions=true ten_enable_test=false


### PR DESCRIPTION
- only lock llvm and rust version for `debug` to enable asan
- remove mac-x64-debug to save ci concurrency