### PR TITLE
feat: improve ci on release

### DIFF
--- a/.github/workflows/build_linux_ubuntu1804.yml
+++ b/.github/workflows/build_linux_ubuntu1804.yml
@@ -1,10 +1,10 @@
 name: Build - linux ubuntu1804
 
 on:
+  release:
+    types: [created]
   push:
     branches:
-      - "**"
-    tags:
       - "**"
     paths-ignore:
       - "tools/**"

--- a/.github/workflows/build_linux_ubuntu2204.yml
+++ b/.github/workflows/build_linux_ubuntu2204.yml
@@ -1,10 +1,10 @@
 name: Build - linux ubuntu2204
 
 on:
+  release:
+    types: [created]
   push:
     branches:
-      - "**"
-    tags:
       - "**"
     paths-ignore:
       - "tools/**"

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "**"
-    tags:
-      - "**"
     paths-ignore:
       - "tools/**"
       - "docs/**"

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "**"
-    tags:
-      - "**"
     paths-ignore:
       - "tools/**"
       - "docs/**"


### PR DESCRIPTION
- trigger linux ci on release created instead of tag pushed to make sure release page available in advance
- no need to build win/mac on release since no artifacts needed at the moment