### PR TITLE
refactor!: restrict addon name to valid programming variable name

### DIFF
--- a/core/src/ten_rust/src/json_schema/data/manifest.schema.json
+++ b/core/src/ten_rust/src/json_schema/data/manifest.schema.json
@@ -81,7 +81,7 @@
             "$ref": "#/$defs/packageType"
           },
           "name": {
-            "$ref": "#/$defs/notEmptyString"
+            "$ref": "#/$defs/alphanumericCharacters"
           },
           "version": {
             "$ref": "#/$defs/versionRequirement"
@@ -383,7 +383,7 @@
       "$ref": "#/$defs/packageType"
     },
     "name": {
-      "$ref": "#/$defs/notEmptyString"
+      "$ref": "#/$defs/alphanumericCharacters"
     },
     "version": {
       "$ref": "#/$defs/version"

--- a/core/src/ten_rust/src/json_schema/data/property.schema.json
+++ b/core/src/ten_rust/src/json_schema/data/property.schema.json
@@ -88,10 +88,10 @@
           "$ref": "#/$defs/notEmptyString"
         },
         "extension_group": {
-          "$ref": "#/$defs/addonInstance"
+          "$ref": "#/$defs/notEmptyString"
         },
         "extension": {
-          "$ref": "#/$defs/addonInstance"
+          "$ref": "#/$defs/notEmptyString"
         },
         "msg_conversion": {
           "type": "object",
@@ -165,10 +165,10 @@
           "$ref": "#/$defs/notEmptyString"
         },
         "extension_group": {
-          "$ref": "#/$defs/addonInstance"
+          "$ref": "#/$defs/notEmptyString"
         },
         "extension": {
-          "$ref": "#/$defs/addonInstance"
+          "$ref": "#/$defs/notEmptyString"
         },
         "msg_conversion": {
           "$ref": "#/$defs/msgConversion"
@@ -194,7 +194,7 @@
           "$ref": "#/$defs/notEmptyString"
         },
         "addon": {
-          "$ref": "#/$defs/notEmptyString"
+          "$ref": "#/$defs/alphanumericCharacters"
         },
         "app": {
           "$ref": "#/$defs/notEmptyString"
@@ -375,29 +375,6 @@
       "items": {
         "$ref": "#/$defs/dataDest"
       }
-    },
-    "addonInstance": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/notEmptyString"
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "addon",
-            "name"
-          ],
-          "properties": {
-            "addon": {
-              "$ref": "#/$defs/notEmptyString"
-            },
-            "name": {
-              "$ref": "#/$defs/notEmptyString"
-            }
-          }
-        }
-      ]
     },
     "validPropertyObject": {
       "type": "object",


### PR DESCRIPTION
refactor!: restrict addon name to valid programming variable name

Previously, any non-empty string could be used as the addon name. To enable the non injection-based
addon registration mechanism in the future, the addon name is now restricted to a valid programming
variable name.

The regular expression is `^[A-Za-z_][A-Za-z0-9_]*$`.

BREAKING CHANGE: The addon name must comply with the regular expression mentioned above.