### PR TITLE
refactor: check duplicated addon name in store

### DIFF
--- a/core/include_internal/ten_runtime/addon/common/store.h
+++ b/core/include_internal/ten_runtime/addon/common/store.h
@@ -23,7 +23,7 @@ typedef struct ten_addon_store_t {
 
 TEN_RUNTIME_PRIVATE_API void ten_addon_store_init(ten_addon_store_t *store);
 
-TEN_RUNTIME_PRIVATE_API void ten_addon_store_add(ten_addon_store_t *store,
+TEN_RUNTIME_PRIVATE_API bool ten_addon_store_add(ten_addon_store_t *store,
                                                  ten_addon_host_t *addon_host);
 
 TEN_RUNTIME_PRIVATE_API ten_addon_t *ten_addon_store_del(

--- a/core/src/ten_runtime/addon/addon.c
+++ b/core/src/ten_runtime/addon/addon.c
@@ -166,9 +166,8 @@ static void ten_addon_load_metadata(ten_addon_host_t *self, ten_env_t *ten_env,
  *
  *   register -> on_init --> on_init_done --> add to the addon store
  *
- * The default behavior in the 'on_init' stage is to loading the metadata of the
- * 'addon'. However, the developer could override the 'on_init' function to
- * perform user-defined operations the addon needs.
+ * Developers could override the 'on_init' function to perform user-defined
+ * operations the addon needs.
  */
 void ten_addon_register(ten_addon_store_t *addon_store,
                         ten_addon_host_t *addon_host, const char *name,

--- a/core/src/ten_runtime/addon/ten_env/on_xxx.c
+++ b/core/src/ten_runtime/addon/ten_env/on_xxx.c
@@ -6,6 +6,8 @@
 //
 #include "include_internal/ten_runtime/addon/ten_env/on_xxx.h"
 
+#include <stdlib.h>
+
 #include "include_internal/ten_runtime/addon/addon.h"
 #include "include_internal/ten_runtime/addon/common/store.h"
 #include "include_internal/ten_runtime/common/constant_str.h"
@@ -71,14 +73,12 @@ void ten_addon_on_init_done(ten_env_t *self) {
           "the manifest.",
           ten_string_get_raw_str(&addon_host->name), manifest_name);
 
-      // TODO(Wei): Enable the following checking. Get 'name' from manifest, and
-      // check the consistency between the name specified in the argument, and
-      // the name specified in the manifest.
+      // Get 'name' from manifest, and check the consistency between the name
+      // specified in the argument, and the name specified in the manifest.
       //
       // The name in the manifest could be checked by the TEN store to ensure
       // the uniqueness of the name.
-      //
-      // TEN_ASSERT(0 && "Should not happen.")
+      TEN_ASSERT(0, "Should not happen.");
     }
 
     // If an extension defines an extension name in its manifest file, TEN
@@ -90,7 +90,11 @@ void ten_addon_on_init_done(ten_env_t *self) {
     }
   }
 
-  ten_addon_store_add(addon_host->store, addon_host);
+  rc = ten_addon_store_add(addon_host->store, addon_host);
+  if (!rc) {
+    TEN_ASSERT(0, "Should not happen.");
+    exit(EXIT_FAILURE);
+  }
 }
 
 void ten_addon_on_deinit_done(ten_env_t *self) {


### PR DESCRIPTION
In addon store, there should be no duplicated addon names.