### PR TITLE
feat: check graph message names

### DIFF
--- a/core/src/ten_rust/src/pkg_info/graph/check/extension_uniqueness_in_connections.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/check/extension_uniqueness_in_connections.rs
@@ -1,0 +1,78 @@
+//
+// Copyright © 2024 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+use std::collections::HashMap;
+
+use anyhow::{Ok, Result};
+
+use crate::pkg_info::graph::Graph;
+
+impl Graph {
+    // The following connection is invalid.
+    //
+    // "connections": [
+    //   {
+    //     "extension": "some_ext",
+    //     "extension_group": "some_group",
+    //     "cmd": [
+    //       {
+    //         "name": "some_cmd",
+    //         "dest": [
+    //           {
+    //             "extension": "ext_2",
+    //             "extension_group": "group_2"
+    //           }
+    //         ]
+    //       }
+    //     ]
+    //   },
+    //   {
+    //     "extension": "some_ext",
+    //     "extension_group": "some_group",
+    //     "cmd": [
+    //       {
+    //         "name": "another_cmd",
+    //         "dest": [
+    //           {
+    //             "extension": "ext_3",
+    //             "extension_group": "group_3"
+    //           }
+    //         ]
+    //       }
+    //     ]
+    //   }
+    // ]
+    pub fn check_extension_uniqueness_in_connections(&self) -> Result<()> {
+        let mut errors: Vec<String> = vec![];
+        let mut extensions: HashMap<String, usize> = HashMap::new();
+
+        for (conn_idx, connection) in
+            self.connections.as_ref().unwrap().iter().enumerate()
+        {
+            let extension = format!(
+                "{}:{}:{}",
+                connection.get_app_uri(),
+                connection.extension_group,
+                connection.extension
+            );
+
+            if let Some(idx) = extensions.get(&extension) {
+                errors.push(format!(
+                    "extension '{}' is defined in connection[{}] and connection[{}], merge them into one section.",
+                    connection.extension, idx, conn_idx
+                ));
+            } else {
+                extensions.insert(extension, conn_idx);
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("{}", errors.join("\n")))
+        }
+    }
+}

--- a/core/src/ten_rust/src/pkg_info/graph/check/message_names.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/check/message_names.rs
@@ -11,71 +11,6 @@ use anyhow::{Ok, Result};
 use crate::pkg_info::graph::{Graph, GraphConnection, GraphMessageFlow};
 
 impl Graph {
-    // The following connection is invalid.
-    //
-    // "connections": [
-    //     {
-    //         "extension": "some_ext",
-    //         "extension_group": "some_group",
-    //         "cmd": [
-    //             {
-    //                 "name": "some_cmd",
-    //                 "dest": [
-    //                     {
-    //                         "extension": "ext_2",
-    //                         "extension_group": "group_2"
-    //                     }
-    //                 ]
-    //             }
-    //         ]
-    //     },
-    //     {
-    //         "extension": "some_ext",
-    //         "extension_group": "some_group",
-    //         "cmd": [
-    //             {
-    //                 "name": "another_cmd",
-    //                 "dest": [
-    //                     {
-    //                         "extension": "ext_3",
-    //                         "extension_group": "group_3"
-    //                     }
-    //                 ]
-    //             }
-    //         ]
-    //     }
-    // ]
-    fn check_if_each_extension_in_only_one_section(&self) -> Result<()> {
-        let mut errors: Vec<String> = vec![];
-        let mut extensions: HashMap<String, usize> = HashMap::new();
-
-        for (conn_idx, connection) in
-            self.connections.as_ref().unwrap().iter().enumerate()
-        {
-            let extension = format!(
-                "{}:{}:{}",
-                connection.get_app_uri(),
-                connection.extension_group,
-                connection.extension
-            );
-
-            if let Some(idx) = extensions.get(&extension) {
-                errors.push(format!(
-                    "extension '{}' is defined in connection[{}] and connection[{}], merge them into one section.",
-                    connection.extension, idx, conn_idx
-                ));
-            } else {
-                extensions.insert(extension, conn_idx);
-            }
-        }
-
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("{}", errors.join("\n")))
-        }
-    }
-
     fn check_if_message_names_are_duplicated(&self) -> Result<()> {
         let mut errors: Vec<String> = vec![];
         for (conn_idx, connection) in
@@ -193,7 +128,6 @@ impl Graph {
             return Ok(());
         }
 
-        self.check_if_each_extension_in_only_one_section()?;
         self.check_if_message_names_are_duplicated()?;
 
         Ok(())

--- a/core/src/ten_rust/src/pkg_info/graph/check/message_names.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/check/message_names.rs
@@ -1,0 +1,201 @@
+//
+// Copyright © 2024 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+use std::collections::HashMap;
+
+use anyhow::{Ok, Result};
+
+use crate::pkg_info::graph::{Graph, GraphConnection, GraphMessageFlow};
+
+impl Graph {
+    // The following connection is invalid.
+    //
+    // "connections": [
+    //     {
+    //         "extension": "some_ext",
+    //         "extension_group": "some_group",
+    //         "cmd": [
+    //             {
+    //                 "name": "some_cmd",
+    //                 "dest": [
+    //                     {
+    //                         "extension": "ext_2",
+    //                         "extension_group": "group_2"
+    //                     }
+    //                 ]
+    //             }
+    //         ]
+    //     },
+    //     {
+    //         "extension": "some_ext",
+    //         "extension_group": "some_group",
+    //         "cmd": [
+    //             {
+    //                 "name": "another_cmd",
+    //                 "dest": [
+    //                     {
+    //                         "extension": "ext_3",
+    //                         "extension_group": "group_3"
+    //                     }
+    //                 ]
+    //             }
+    //         ]
+    //     }
+    // ]
+    fn check_if_each_extension_in_only_one_section(&self) -> Result<()> {
+        let mut errors: Vec<String> = vec![];
+        let mut extensions: HashMap<String, usize> = HashMap::new();
+
+        for (conn_idx, connection) in
+            self.connections.as_ref().unwrap().iter().enumerate()
+        {
+            let extension = format!(
+                "{}:{}:{}",
+                connection.get_app_uri(),
+                connection.extension_group,
+                connection.extension
+            );
+
+            if let Some(idx) = extensions.get(&extension) {
+                errors.push(format!(
+                    "extension '{}' is defined in connection[{}] and connection[{}], merge them into one section.",
+                    connection.extension, idx, conn_idx
+                ));
+            } else {
+                extensions.insert(extension, conn_idx);
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("{}", errors.join("\n")))
+        }
+    }
+
+    fn check_if_message_names_are_duplicated(&self) -> Result<()> {
+        let mut errors: Vec<String> = vec![];
+        for (conn_idx, connection) in
+            self.connections.as_ref().unwrap().iter().enumerate()
+        {
+            if let Some(errs) =
+                self.check_if_message_name_duplicated_in_connection(connection)
+            {
+                errors.push(format!("- connection[{}]:", conn_idx));
+                for err in errs {
+                    errors.push(format!("  {}", err));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("{}", errors.join("\n")))
+        }
+    }
+
+    fn check_if_message_name_duplicated_group_by_msg_type(
+        &self,
+        flows: &[GraphMessageFlow],
+    ) -> Vec<String> {
+        let mut errors: Vec<String> = vec![];
+
+        let mut msg_names: HashMap<String, usize> = HashMap::new();
+        for (flow_idx, flow) in flows.iter().enumerate() {
+            if let Some(idx) = msg_names.get(&flow.name) {
+                errors.push(format!(
+                    "'{}' is defined in flow[{}] and flow[{}].",
+                    flow.name, idx, flow_idx
+                ));
+            } else {
+                msg_names.insert(flow.name.clone(), flow_idx);
+            }
+        }
+
+        errors
+    }
+
+    fn check_if_message_name_duplicated_in_connection(
+        &self,
+        connection: &GraphConnection,
+    ) -> Option<Vec<String>> {
+        let mut errors: Vec<String> = vec![];
+
+        if let Some(cmd) = &connection.cmd {
+            let errs =
+                self.check_if_message_name_duplicated_group_by_msg_type(cmd);
+            if !errs.is_empty() {
+                errors.push(
+                    "- Merge the following cmd into one section:".to_string(),
+                );
+                for err in errs {
+                    errors.push(format!("  {}", err));
+                }
+            }
+        }
+
+        if let Some(data) = &connection.data {
+            let errs =
+                self.check_if_message_name_duplicated_group_by_msg_type(data);
+            if !errs.is_empty() {
+                errors.push(
+                    "- Merge the following data into one section:".to_string(),
+                );
+                for err in errs {
+                    errors.push(format!("  {}", err));
+                }
+            }
+        }
+
+        if let Some(audio_frame) = &connection.audio_frame {
+            let errs = self.check_if_message_name_duplicated_group_by_msg_type(
+                audio_frame,
+            );
+            if !errs.is_empty() {
+                errors.push(
+                    "- Merge the following auto_frame into one section:"
+                        .to_string(),
+                );
+                for err in errs {
+                    errors.push(format!("  {}", err));
+                }
+            }
+        }
+
+        if let Some(video_frame) = &connection.video_frame {
+            let errs = self.check_if_message_name_duplicated_group_by_msg_type(
+                video_frame,
+            );
+            if !errs.is_empty() {
+                errors.push(
+                    "- Merge the following video_frame into one section:"
+                        .to_string(),
+                );
+                for err in errs {
+                    errors.push(format!("  {}", err));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            None
+        } else {
+            Some(errors)
+        }
+    }
+
+    pub fn check_message_names(&self) -> Result<()> {
+        if self.connections.is_none() {
+            return Ok(());
+        }
+
+        self.check_if_each_extension_in_only_one_section()?;
+        self.check_if_message_names_are_duplicated()?;
+
+        Ok(())
+    }
+}

--- a/core/src/ten_rust/src/pkg_info/graph/check/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/check/mod.rs
@@ -7,5 +7,6 @@
 pub mod connections_are_compatible;
 pub mod connections_nodes_are_defined;
 pub mod duplicated_nodes;
+pub mod extension_uniqueness_in_connections;
 pub mod message_names;
 pub mod nodes_are_installed;

--- a/core/src/ten_rust/src/pkg_info/graph/check/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/check/mod.rs
@@ -7,4 +7,5 @@
 pub mod connections_are_compatible;
 pub mod connections_nodes_are_defined;
 pub mod duplicated_nodes;
+pub mod message_names;
 pub mod nodes_are_installed;

--- a/core/src/ten_rust/src/pkg_info/graph/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/mod.rs
@@ -75,6 +75,7 @@ impl Graph {
         self.check_if_extensions_used_in_connections_have_defined_in_nodes()?;
         self.check_if_nodes_have_installed(existed_pkgs_of_all_apps)?;
         self.check_connections_compatible(existed_pkgs_of_all_apps)?;
+        self.check_extension_uniqueness_in_connections()?;
         self.check_message_names()?;
 
         Ok(())
@@ -468,7 +469,8 @@ mod tests {
         );
 
         let graph = Graph::from_str(graph_str).unwrap();
-        let result = graph.check_message_names();
+
+        let result = graph.check_extension_uniqueness_in_connections();
 
         assert!(result.is_err());
         println!("Error: {:?}", result);

--- a/core/src/ten_rust/src/pkg_info/graph/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/graph/mod.rs
@@ -62,6 +62,7 @@ impl Graph {
         self.check_if_extensions_used_in_connections_have_defined_in_nodes()?;
         self.check_if_nodes_have_installed(existed_pkgs_of_all_apps)?;
         self.check_connections_compatible(existed_pkgs_of_all_apps)?;
+        self.check_message_names()?;
 
         Ok(())
     }
@@ -330,5 +331,47 @@ mod tests {
         // App uri should be some string other than 'localhost'.
         assert!(property.is_err());
         println!("Error: {:?}", property.err().unwrap());
+    }
+
+    #[test]
+    fn test_graph_same_extension_in_two_section_of_connections() {
+        let graph_str = include_str!(
+            "test_data_embed/graph_same_extension_in_two_section_of_connections.json"
+        );
+
+        let graph = Graph::from_str(graph_str).unwrap();
+        let result = graph.check_message_names();
+
+        assert!(result.is_err());
+        println!("Error: {:?}", result);
+
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("extension 'some_extension' is defined in connection[0] and connection[1]"));
+    }
+
+    #[test]
+    fn test_graph_duplicated_cmd_name_in_one_connection() {
+        let graph_str = include_str!(
+            "test_data_embed/graph_duplicated_cmd_name_in_one_connection.json"
+        );
+
+        let graph = Graph::from_str(graph_str).unwrap();
+        let result = graph.check_message_names();
+        assert!(result.is_err());
+        println!("Error: {:?}", result);
+
+        let msg = result.err().unwrap().to_string();
+        assert!(msg.contains("'hello' is defined in flow[0] and flow[1]"));
+    }
+
+    #[test]
+    fn test_graph_messages_same_name_in_different_type_are_ok() {
+        let graph_str = include_str!(
+            "test_data_embed/graph_messages_same_name_in_different_type_are_ok.json"
+        );
+
+        let graph = Graph::from_str(graph_str).unwrap();
+        let result = graph.check_message_names();
+        assert!(result.is_ok());
     }
 }

--- a/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_duplicated_cmd_name_in_one_connection.json
+++ b/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_duplicated_cmd_name_in_one_connection.json
@@ -1,0 +1,67 @@
+{
+  "nodes": [
+    {
+      "type": "extension",
+      "name": "some_extension",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    },
+    {
+      "type": "extension",
+      "name": "another_ext",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    },
+    {
+      "type": "extension",
+      "name": "third_ext",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    }
+  ],
+  "connections": [
+    {
+      "extension": "some_extension",
+      "extension_group": "some_group",
+      "cmd": [
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "another_ext"
+            }
+          ]
+        },
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "third_ext"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": "another_ext",
+      "extension_group": "some_group",
+      "data": [
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "third_ext"
+            },
+            {
+              "extension_group": "some_group",
+              "extension": "some_extension"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_messages_same_name_in_different_type_are_ok.json
+++ b/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_messages_same_name_in_different_type_are_ok.json
@@ -1,0 +1,50 @@
+{
+  "nodes": [
+    {
+      "type": "extension",
+      "name": "some_extension",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    },
+    {
+      "type": "extension",
+      "name": "another_ext",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    },
+    {
+      "type": "extension",
+      "name": "third_ext",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    }
+  ],
+  "connections": [
+    {
+      "extension": "some_extension",
+      "extension_group": "some_group",
+      "cmd": [
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "another_ext"
+            }
+          ]
+        }
+      ],
+      "data": [
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "third_ext"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_same_extension_in_two_section_of_connections.json
+++ b/core/src/ten_rust/src/pkg_info/graph/test_data_embed/graph_same_extension_in_two_section_of_connections.json
@@ -1,0 +1,48 @@
+{
+  "nodes": [
+    {
+      "type": "extension",
+      "name": "some_extension",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    },
+    {
+      "type": "extension",
+      "name": "another_ext",
+      "addon": "default_extension_go",
+      "extension_group": "some_group"
+    }
+  ],
+  "connections": [
+    {
+      "extension": "some_extension",
+      "extension_group": "some_group",
+      "cmd": [
+        {
+          "name": "hello",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "another_ext"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "extension": "some_extension",
+      "extension_group": "some_group",
+      "cmd": [
+        {
+          "name": "hello_2",
+          "dest": [
+            {
+              "extension_group": "some_group",
+              "extension": "another_ext"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
1. 同一个 extension 不能分散定义在多个 connection 中
2. 同一个 connection 中的每一类消息, 不能有重复的 name