### PR TITLE
fix: add some logs if env is not found

### DIFF
--- a/core/src/ten_utils/lib/sys/general/placeholder.c
+++ b/core/src/ten_utils/lib/sys/general/placeholder.c
@@ -185,8 +185,14 @@ bool ten_placeholder_resolve(ten_placeholder_t *self,
         // Environment variable not found, use default value.
         if (!ten_value_is_valid(&self->default_value)) {
           // If no default value is provided, use 'null' value.
+          TEN_LOGI(
+              "Environment variable %s is not found, neither default value is "
+              "provided, set property to null.",
+              variable_name);
           ten_value_reset_to_null(placeholder_value);
         } else {
+          TEN_LOGI("Environment variable %s is not found, using default value.",
+                   variable_name);
           const char *default_value =
               ten_value_peek_raw_str(&self->default_value);
           ten_value_reset_to_string_with_size(placeholder_value, default_value,


### PR DESCRIPTION
Ex:

```text
11-04 18:45:22.995 4093961(4094172) I ten_placeholder_resolve@placeholder.c:191 Environment variable ENV_NOT_SET is not found, neither default value is provided, set property to null.
11-04 18:45:22.995 4093961(4094172) I ten_placeholder_resolve@placeholder.c:195 Environment variable ENV_NOT_SET is not found, using default value.
```