### PR TITLE
fix: conflicted error msg

### DIFF
--- a/core/src/ten_manager/src/cmd/cmd_install.rs
+++ b/core/src/ten_manager/src/cmd/cmd_install.rs
@@ -861,7 +861,7 @@ do you want to continue?",
 
         Ok(())
     } else {
-        // The last model always represents the latest version.
+        // The last model always represents the optimal version.
         //
         // The first error messages (i.e., non_usable_models.first()) might be
         // changed when we run `tman install` in an app folder, if the app
@@ -904,19 +904,15 @@ do you want to continue?",
         // depends_on_declared("app", "ten_agent", "0.4.0", "extension", "agora_rtm", "0.1.0").
         // depends_on_declared("app", "ten_agent", "0.4.0", "extension", "agora_rtm", "0.1.1").
         // ```
-        //
-        // When clingo analyzes the input.lp, it generates the answer models
-        // based on the order of the `depends_on_declared` facts. If there is no
-        // answer for the version declared in the first `depends_on_declared`
-        // fact, it will ignore the versions smaller than it. Ex: in case 1,
-        // there will be answer models for both 0.1.0, 0.1.1 and 0.1.2, and the
-        // first model is for 0.1.0, and the last is for 0.1.2. While in case 2,
-        // there only be answer models for 0.1.2. If we take the first error
-        // message (i.e., non_usable_models.first()) from the answer models, the
-        // error messages for those two cases are as above.
-        //
-        // That's also why we need to take the last model as the final error
-        // message.
+        // Due to the different order of input data, clingo may start searching
+        // from different points. However, clingo will only output increasingly
+        // better models. Therefore, if we select the first `non_usable_models`,
+        // it is often inconsistent. But if we select the last model, it is
+        // usually consistent, representing the optimal error model that clingo
+        // can find. This phenomenon is similar to the gradient descent process
+        // in neural networks that seeks local optima. Thus, we should select
+        // the last model to obtain the optimal error model and achieve stable
+        // results.
         if let Some(non_usable_model) = non_usable_models.last() {
             // Extract introducer relations, and parse the error message.
             if let Ok(conflict_info) = parse_error_statement(non_usable_model) {

--- a/core/src/ten_manager/src/cmd/cmd_install.rs
+++ b/core/src/ten_manager/src/cmd/cmd_install.rs
@@ -505,7 +505,7 @@ pub async fn execute_cmd(
         let desired_pkg_type_: PkgType = package_type_str.parse()?;
         let (
             desired_pkg_src_name_,
-            desired_pkg_requested_version,
+            desired_pkg_src_version_str_,
             desired_pkg_src_version_,
         ) = parse_pkg_name_version(&command_data.package_name.unwrap())?;
 
@@ -559,7 +559,7 @@ pub async fn execute_cmd(
                         name: desired_pkg_src_name_.clone(),
                     },
                     version_req: desired_pkg_src_version_.clone(),
-                    original_version_req: desired_pkg_requested_version,
+                    version_req_str: desired_pkg_src_version_str_,
                 },
             };
             extra_dependency_relationships.push(extra_dependency_relationship);

--- a/core/src/ten_manager/src/manifest_lock/mod.rs
+++ b/core/src/ten_manager/src/manifest_lock/mod.rs
@@ -253,7 +253,7 @@ impl<'a> From<&'a ManifestLockItem> for PkgInfo {
                                 name: dep.name,
                             },
                             version_req: VersionReq::STAR,
-                            original_version_req: None,
+                            version_req_str: None,
                         })
                         .collect()
                 })

--- a/core/src/ten_manager/src/manifest_lock/mod.rs
+++ b/core/src/ten_manager/src/manifest_lock/mod.rs
@@ -253,6 +253,7 @@ impl<'a> From<&'a ManifestLockItem> for PkgInfo {
                                 name: dep.name,
                             },
                             version_req: VersionReq::STAR,
+                            original_version_req: None,
                         })
                         .collect()
                 })

--- a/core/src/ten_manager/src/solver/introducer.rs
+++ b/core/src/ten_manager/src/solver/introducer.rs
@@ -88,9 +88,9 @@ pub fn extract_introducer_relations_from_raw_solver_results(
 
 pub fn get_dependency_chain(
     introducer: &PkgInfo,
-    conflict_pkg: &PkgInfo,
+    conflict_pkg_identity: &PkgIdentity,
     introducer_relations: &HashMap<PkgInfo, (String, Option<PkgInfo>)>,
-) -> Vec<(String, PkgInfo)> {
+) -> Vec<(String, PkgIdentity)> {
     let mut chain = Vec::new();
     let mut current_pkg = introducer.clone();
     let mut visited = HashSet::new();
@@ -99,8 +99,8 @@ pub fn get_dependency_chain(
     // dependency chain first.
     let requested_dep_in_introducer = introducer
         .get_dependency_by_type_and_name(
-            &conflict_pkg.pkg_identity.pkg_type.to_string(),
-            &conflict_pkg.pkg_identity.name,
+            &conflict_pkg_identity.pkg_type.to_string(),
+            &conflict_pkg_identity.name,
         )
         .unwrap();
     chain.push((
@@ -109,7 +109,7 @@ pub fn get_dependency_chain(
             .as_ref()
             .unwrap()
             .clone(),
-        conflict_pkg.clone(),
+        conflict_pkg_identity.clone(),
     ));
 
     loop {
@@ -124,12 +124,18 @@ pub fn get_dependency_chain(
                 // `current_pkg`@`requested_version`, i.e., the
                 // `requested_version` is used to declared the `current_pkg` in
                 // the manifest.json of `introducer_pkg`.
-                chain.push((requested_version.clone(), current_pkg.clone()));
+                chain.push((
+                    requested_version.clone(),
+                    current_pkg.pkg_identity.clone(),
+                ));
                 current_pkg = introducer_pkg.clone();
             }
             Some((requested_version, None)) => {
                 // Reached the root.
-                chain.push((requested_version.clone(), current_pkg.clone()));
+                chain.push((
+                    requested_version.clone(),
+                    current_pkg.pkg_identity.clone(),
+                ));
                 break;
             }
             None => {

--- a/core/src/ten_manager/src/solver/introducer.rs
+++ b/core/src/ten_manager/src/solver/introducer.rs
@@ -13,16 +13,17 @@ use ten_rust::pkg_info::{pkg_identity::PkgIdentity, PkgInfo};
 
 use crate::dep_and_candidate::get_pkg_info_from_candidates;
 
+/// Returns a map from a package to its introducer and the requested version.
 pub fn extract_introducer_relations_from_raw_solver_results(
     results: &[String],
     all_candidates: &HashMap<PkgIdentity, HashSet<PkgInfo>>,
-) -> Result<HashMap<PkgInfo, Option<PkgInfo>>> {
+) -> Result<HashMap<PkgInfo, (String, Option<PkgInfo>)>> {
     let re = Regex::new(
       r#"introducer\("([^"]+)","([^"]+)","([^"]+)","([^"]+)","([^"]*)","([^"]*)"\)"#,
   )
   .unwrap();
 
-    let mut introducer_relations: HashMap<PkgInfo, Option<PkgInfo>> =
+    let mut introducer_relations: HashMap<PkgInfo, (String, Option<PkgInfo>)> =
         HashMap::new();
 
     for result in results.iter() {
@@ -34,6 +35,10 @@ pub fn extract_introducer_relations_from_raw_solver_results(
             let introducer_type_str = caps.get(4).unwrap().as_str();
             let introducer_name = caps.get(5).unwrap().as_str();
             let introducer_version_str = caps.get(6).unwrap().as_str();
+
+            // Using the requested version (i.e., the version field declared in
+            // manifest.json) in the dependency chain is more user-friendly.
+            let mut requested_version_str = version_str.to_string();
 
             let pkg_info = get_pkg_info_from_candidates(
                 pkg_type_str,
@@ -52,10 +57,29 @@ pub fn extract_introducer_relations_from_raw_solver_results(
                     all_candidates,
                 )?;
 
+                let requested_dep_in_introducer = introducer_info
+                    .get_dependency_by_type_and_name(pkg_type_str, name);
+                if let Some(requested_dep_in_introducer) =
+                    requested_dep_in_introducer
+                {
+                    // The `version` declared in the `dependencies` section in
+                    // manifest.json is always present.
+                    requested_version_str = requested_dep_in_introducer
+                        .original_version_req
+                        .as_ref()
+                        .unwrap()
+                        .clone();
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Requested dependency [{}]{} not found in introducer, should not happen.", pkg_type_str, name
+                    ));
+                }
+
                 Some(introducer_info.clone())
             };
 
-            introducer_relations.insert(pkg_info.clone(), introducer);
+            introducer_relations
+                .insert(pkg_info.clone(), (requested_version_str, introducer));
         }
     }
 
@@ -63,12 +87,30 @@ pub fn extract_introducer_relations_from_raw_solver_results(
 }
 
 pub fn get_dependency_chain(
-    pkg_info: &PkgInfo,
-    introducer_relations: &HashMap<PkgInfo, Option<PkgInfo>>,
-) -> Vec<PkgInfo> {
+    introducer: &PkgInfo,
+    conflicted_pkg: &PkgInfo,
+    introducer_relations: &HashMap<PkgInfo, (String, Option<PkgInfo>)>,
+) -> Vec<(String, PkgInfo)> {
     let mut chain = Vec::new();
-    let mut current_pkg = pkg_info.clone();
+    let mut current_pkg = introducer.clone();
     let mut visited = HashSet::new();
+
+    // Add the leaf node (i.e., `introducer` depends on `pkg_name`) to the
+    // dependency chain first.
+    let requested_dep_in_introducer = introducer
+        .get_dependency_by_type_and_name(
+            &conflicted_pkg.pkg_identity.pkg_type.to_string(),
+            &conflicted_pkg.pkg_identity.name,
+        )
+        .unwrap();
+    chain.push((
+        requested_dep_in_introducer
+            .original_version_req
+            .as_ref()
+            .unwrap()
+            .clone(),
+        conflicted_pkg.clone(),
+    ));
 
     loop {
         if !visited.insert(current_pkg.clone()) {
@@ -76,14 +118,18 @@ pub fn get_dependency_chain(
             break;
         }
 
-        chain.push(current_pkg.clone());
-
         match introducer_relations.get(&current_pkg) {
-            Some(Some(introducer_pkg)) => {
+            Some((requested_version, Some(introducer_pkg))) => {
+                // The dependency chain is that `introducer_pkg` depends on
+                // `current_pkg`@`requested_version`, i.e., the
+                // `requested_version` is used to declared the `current_pkg` in
+                // the manifest.json of `introducer_pkg`.
+                chain.push((requested_version.clone(), current_pkg.clone()));
                 current_pkg = introducer_pkg.clone();
             }
-            Some(None) => {
+            Some((requested_version, None)) => {
                 // Reached the root.
+                chain.push((requested_version.clone(), current_pkg.clone()));
                 break;
             }
             None => {

--- a/core/src/ten_manager/src/solver/introducer.rs
+++ b/core/src/ten_manager/src/solver/introducer.rs
@@ -65,7 +65,7 @@ pub fn extract_introducer_relations_from_raw_solver_results(
                     // The `version` declared in the `dependencies` section in
                     // manifest.json is always present.
                     requested_version_str = requested_dep_in_introducer
-                        .original_version_req
+                        .version_req_str
                         .as_ref()
                         .unwrap()
                         .clone();
@@ -88,7 +88,7 @@ pub fn extract_introducer_relations_from_raw_solver_results(
 
 pub fn get_dependency_chain(
     introducer: &PkgInfo,
-    conflicted_pkg: &PkgInfo,
+    conflict_pkg: &PkgInfo,
     introducer_relations: &HashMap<PkgInfo, (String, Option<PkgInfo>)>,
 ) -> Vec<(String, PkgInfo)> {
     let mut chain = Vec::new();
@@ -99,17 +99,17 @@ pub fn get_dependency_chain(
     // dependency chain first.
     let requested_dep_in_introducer = introducer
         .get_dependency_by_type_and_name(
-            &conflicted_pkg.pkg_identity.pkg_type.to_string(),
-            &conflicted_pkg.pkg_identity.name,
+            &conflict_pkg.pkg_identity.pkg_type.to_string(),
+            &conflict_pkg.pkg_identity.name,
         )
         .unwrap();
     chain.push((
         requested_dep_in_introducer
-            .original_version_req
+            .version_req_str
             .as_ref()
             .unwrap()
             .clone(),
-        conflicted_pkg.clone(),
+        conflict_pkg.clone(),
     ));
 
     loop {

--- a/core/src/ten_manager/src/solver/solver_error.rs
+++ b/core/src/ten_manager/src/solver/solver_error.rs
@@ -18,18 +18,21 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct ConflictPkg {
+pub struct ConflictPkgVersion {
+    // The version of the pkg that causes the conflict, introduced by the
+    // following introducer.
+    pub pkg_version: String,
+
     pub introducer_type: String,
     pub introducer_name: String,
     pub introducer_version: String,
-
-    // The version of the pkg that causes the conflict, introduced by the
-    // introducer.
-    pub pkg_version: String,
 }
 
 #[derive(Debug)]
 pub struct ConflictInfo {
+    pub conflict_pkg_type: String,
+    pub conflict_pkg_name: String,
+
     // The introducers are needed to get the dependency chain. The conflicted
     // pkg (i.e., pkg_type and pkg_name) can not be used to get the dependency
     // chain, considering the following scenario:
@@ -51,10 +54,9 @@ pub struct ConflictInfo {
     //    └─ [extension]D@0.2.1
     //
     // But what we want is the chain leading to D@0.2.0.
-    pub left: ConflictPkg,
-    pub right: ConflictPkg,
-    pub pkg_type: String,
-    pub pkg_name: String,
+    pub conflict_pkg_version_1: ConflictPkgVersion,
+    pub conflict_pkg_version_2: ConflictPkgVersion,
+
     pub error_message: String,
 }
 
@@ -93,20 +95,22 @@ pub fn parse_error_statement(clingo_output: &[String]) -> Result<ConflictInfo> {
                 .replace("{9}", &introducer2_version);
 
             return Ok(ConflictInfo {
-                left: ConflictPkg {
+                conflict_pkg_type: pkg_type,
+                conflict_pkg_name: pkg_name,
+
+                conflict_pkg_version_1: ConflictPkgVersion {
                     introducer_type: introducer1_type,
                     introducer_name: introducer1_name,
                     introducer_version: introducer1_version,
                     pkg_version: version1,
                 },
-                right: ConflictPkg {
+                conflict_pkg_version_2: ConflictPkgVersion {
                     introducer_type: introducer2_type,
                     introducer_name: introducer2_name,
                     introducer_version: introducer2_version,
                     pkg_version: version2,
                 },
-                pkg_type,
-                pkg_name,
+
                 error_message,
             });
         }
@@ -150,50 +154,57 @@ pub fn print_conflict_info(
     );
     println!();
 
-    // Get PkgInfo for both versions
-    let pkg_info1 = get_pkg_info_from_candidates(
-        &conflict_info.left.introducer_type,
-        &conflict_info.left.introducer_name,
-        &conflict_info.left.introducer_version,
+    // Get PkgInfo for both introducer packages.
+    let introducer_pkg_info_1 = get_pkg_info_from_candidates(
+        &conflict_info.conflict_pkg_version_1.introducer_type,
+        &conflict_info.conflict_pkg_version_1.introducer_name,
+        &conflict_info.conflict_pkg_version_1.introducer_version,
         all_candidates,
     )?;
-    let pkg_info2 = get_pkg_info_from_candidates(
-        &conflict_info.right.introducer_type,
-        &conflict_info.right.introducer_name,
-        &conflict_info.right.introducer_version,
+    let introducer_pkg_info_2 = get_pkg_info_from_candidates(
+        &conflict_info.conflict_pkg_version_2.introducer_type,
+        &conflict_info.conflict_pkg_version_2.introducer_name,
+        &conflict_info.conflict_pkg_version_2.introducer_version,
         all_candidates,
     )?;
 
-    // The pkg_info1/pkg_info2 (i.e., the introducer) depends on the pkg
-    // identified by `pkg_name` (i.e., the leaf node). The pkg_version used
-    // to get the pkg_info does not matter, as it will be replaced by the
-    // original_version_req in the introducer, refer to
-    // `get_dependency_chain()`.
+    // The introducer_pkg_info_1/introducer_pkg_info_2 (i.e., the introducer)
+    // depends on the pkg identified by `conflict_pkg_type` &
+    // `conflict_pkg_name` (i.e., the leaf node). The conflict_pkg_version_x
+    // used to get the pkg_info does not matter, as it will be replaced by
+    // the `version_req_str` of the introducer, refer
+    // to `get_dependency_chain()`.
     let leaf_node_pkg = get_pkg_info_from_candidates(
-        &conflict_info.pkg_type,
-        &conflict_info.pkg_name,
-        &conflict_info.left.pkg_version,
+        &conflict_info.conflict_pkg_type,
+        &conflict_info.conflict_pkg_name,
+        &conflict_info.conflict_pkg_version_1.pkg_version,
         all_candidates,
     )?;
 
     // Get dependency chains
-    let chain1 =
-        get_dependency_chain(&pkg_info1, &leaf_node_pkg, introducer_relations);
-    let chain2 =
-        get_dependency_chain(&pkg_info2, &leaf_node_pkg, introducer_relations);
+    let chain1 = get_dependency_chain(
+        &introducer_pkg_info_1,
+        &leaf_node_pkg,
+        introducer_relations,
+    );
+    let chain2 = get_dependency_chain(
+        &introducer_pkg_info_2,
+        &leaf_node_pkg,
+        introducer_relations,
+    );
 
     print_dependency_chain(
         &chain1,
-        &conflict_info.pkg_type,
-        &conflict_info.pkg_name,
-        &conflict_info.left.pkg_version,
+        &conflict_info.conflict_pkg_type,
+        &conflict_info.conflict_pkg_name,
+        &conflict_info.conflict_pkg_version_1.pkg_version,
     );
 
     print_dependency_chain(
         &chain2,
-        &conflict_info.pkg_type,
-        &conflict_info.pkg_name,
-        &conflict_info.right.pkg_version,
+        &conflict_info.conflict_pkg_type,
+        &conflict_info.conflict_pkg_name,
+        &conflict_info.conflict_pkg_version_2.pkg_version,
     );
 
     Ok(())

--- a/core/src/ten_manager/src/solver/solver_error.rs
+++ b/core/src/ten_manager/src/solver/solver_error.rs
@@ -120,7 +120,7 @@ pub fn parse_error_statement(clingo_output: &[String]) -> Result<ConflictInfo> {
 }
 
 fn print_dependency_chain(
-    chain: &[(String, PkgInfo)],
+    chain: &[(String, PkgIdentity)],
     pkg_type: &str,
     pkg_name: &str,
     version: &str,
@@ -133,8 +133,8 @@ fn print_dependency_chain(
         println!(
             "{:indent$}└─ [{}]{}@{}",
             "",
-            pkg.1.pkg_identity.pkg_type,
-            pkg.1.pkg_identity.name,
+            pkg.1.pkg_type,
+            pkg.1.name,
             pkg.0,
             indent = i * 3
         );
@@ -169,27 +169,21 @@ pub fn print_conflict_info(
     )?;
 
     // The introducer_pkg_info_1/introducer_pkg_info_2 (i.e., the introducer)
-    // depends on the pkg identified by `conflict_pkg_type` &
-    // `conflict_pkg_name` (i.e., the leaf node). The conflict_pkg_version_x
-    // used to get the pkg_info does not matter, as it will be replaced by
-    // the `version_req_str` of the introducer, refer
-    // to `get_dependency_chain()`.
-    let leaf_node_pkg = get_pkg_info_from_candidates(
-        &conflict_info.conflict_pkg_type,
-        &conflict_info.conflict_pkg_name,
-        &conflict_info.conflict_pkg_version_1.pkg_version,
-        all_candidates,
-    )?;
+    // depends on the pkg identified by `conflict_pkg_identity`.
+    let conflict_pkg_identity = PkgIdentity {
+        pkg_type: conflict_info.conflict_pkg_type.parse()?,
+        name: conflict_info.conflict_pkg_name.clone(),
+    };
 
-    // Get dependency chains
+    // Get dependency chains.
     let chain1 = get_dependency_chain(
         &introducer_pkg_info_1,
-        &leaf_node_pkg,
+        &conflict_pkg_identity,
         introducer_relations,
     );
     let chain2 = get_dependency_chain(
         &introducer_pkg_info_2,
-        &leaf_node_pkg,
+        &conflict_pkg_identity,
         introducer_relations,
     );
 

--- a/core/src/ten_rust/src/pkg_info/dependencies.rs
+++ b/core/src/ten_rust/src/pkg_info/dependencies.rs
@@ -19,12 +19,15 @@ use crate::pkg_info::manifest::{dependency::ManifestDependency, Manifest};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PkgDependency {
     pub pkg_identity: PkgIdentity,
-    pub version_req: VersionReq,
 
-    // The original requested version of this dependency, ex: the `version`
+    // The version requirement of this dependency, ex: the `version`
     // field declared in the `dependencies` section in the manifest.json, or
     // the `pkg@version` parameter in the command line.
-    pub original_version_req: Option<String>,
+    //
+    // The `version_req_str` is the original value in string form, while
+    // `version_req` is the result after being converted to `VersionReq`.
+    pub version_req: VersionReq,
+    pub version_req_str: Option<String>,
 }
 
 pub fn get_pkg_dependencies_from_manifest(
@@ -53,7 +56,7 @@ pub fn get_pkg_dependencies_from_manifest_dependencies(
         dependencies.push(PkgDependency {
             pkg_identity: PkgIdentity { pkg_type, name },
             version_req,
-            original_version_req: Some(manifest_dependency.version.clone()),
+            version_req_str: Some(manifest_dependency.version.clone()),
         });
     }
 
@@ -83,7 +86,7 @@ impl PkgDependency {
         PkgDependency {
             pkg_identity: PkgIdentity { pkg_type, name },
             version_req,
-            original_version_req: None,
+            version_req_str: None,
         }
     }
 }

--- a/core/src/ten_rust/src/pkg_info/dependencies.rs
+++ b/core/src/ten_rust/src/pkg_info/dependencies.rs
@@ -20,6 +20,11 @@ use crate::pkg_info::manifest::{dependency::ManifestDependency, Manifest};
 pub struct PkgDependency {
     pub pkg_identity: PkgIdentity,
     pub version_req: VersionReq,
+
+    // The original requested version of this dependency, ex: the `version`
+    // field declared in the `dependencies` section in the manifest.json, or
+    // the `pkg@version` parameter in the command line.
+    pub original_version_req: Option<String>,
 }
 
 pub fn get_pkg_dependencies_from_manifest(
@@ -48,6 +53,7 @@ pub fn get_pkg_dependencies_from_manifest_dependencies(
         dependencies.push(PkgDependency {
             pkg_identity: PkgIdentity { pkg_type, name },
             version_req,
+            original_version_req: Some(manifest_dependency.version.clone()),
         });
     }
 
@@ -77,6 +83,7 @@ impl PkgDependency {
         PkgDependency {
             pkg_identity: PkgIdentity { pkg_type, name },
             version_req,
+            original_version_req: None,
         }
     }
 }

--- a/core/src/ten_rust/src/pkg_info/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/mod.rs
@@ -219,11 +219,11 @@ impl PkgInfo {
     pub fn get_dependency_by_type_and_name(
         &self,
         pkg_type: &str,
-        name: &str,
+        pkg_name: &str,
     ) -> Option<&PkgDependency> {
         self.dependencies.iter().find(|dep| {
             dep.pkg_identity.pkg_type.to_string() == pkg_type
-                && dep.pkg_identity.name == name
+                && dep.pkg_identity.name == pkg_name
         })
     }
 }

--- a/core/src/ten_rust/src/pkg_info/mod.rs
+++ b/core/src/ten_rust/src/pkg_info/mod.rs
@@ -215,6 +215,17 @@ impl PkgInfo {
             }
         }
     }
+
+    pub fn get_dependency_by_type_and_name(
+        &self,
+        pkg_type: &str,
+        name: &str,
+    ) -> Option<&PkgDependency> {
+        self.dependencies.iter().find(|dep| {
+            dep.pkg_identity.pkg_type.to_string() == pkg_type
+                && dep.pkg_identity.name == name
+        })
+    }
 }
 
 pub fn get_pkg_info_from_path(pkg_path: &Path) -> Result<PkgInfo> {


### PR DESCRIPTION
Ex:

Running `tman install` in app:

```text
❌  Error: Select more than 1 version of '[system]ten_runtime': '@0.2.0' introduced by '[extension]agora_rtm@0.1.1', and '@0.3.0' introduced by '[system]ten_runtime_go@0.3.0'

Dependency chain leading to [system]ten_runtime@0.2.0:
└─ [app]ten_agent@0.4.0
   └─ [extension]agora_rtm@<=0.1.2
      └─ [system]ten_runtime@^0.2

Dependency chain leading to [system]ten_runtime@0.3.0:
└─ [app]ten_agent@0.4.0
   └─ [system]ten_runtime_go@=0.3.0
      └─ [system]ten_runtime@^0.3.0

❌  Error: Dependency resolution failed.
```

Running `tman install` in extension:

```text
❌  Error: Select more than 1 version of '[system]ten_runtime': '@0.2.0' introduced by '[extension]agora_rtm@0.1.1', and '@0.3.1' introduced by '[extension]edge_metrics_extension_go@0.1.0'

Dependency chain leading to [system]ten_runtime@0.2.0:
└─ [extension]edge_metrics_extension_go@0.1.0
   └─ [extension]agora_rtm@<=0.1.2
      └─ [system]ten_runtime@^0.2

Dependency chain leading to [system]ten_runtime@0.3.1:
└─ [extension]edge_metrics_extension_go@0.1.0
   └─ [system]ten_runtime@0.3

❌  Error: Dependency resolution failed.
```