### PR TITLE
docs: spelling examples

### DIFF
--- a/docs/ten_agent/demo/quickstart.md
+++ b/docs/ten_agent/demo/quickstart.md
@@ -9,7 +9,7 @@ The easiest way to run the demo is to use the pre-built Docker image. The image 
 After you successfully setup, you will need to run an additional command to switch graph folder to demo folder,
 
 ```bash
-task use AGENT=agents/exmaples/demo
+task use AGENT=agents/examples/demo
 ```
 
 Once finished, you can access the demo by opening the browser and navigating to `http://localhost:3002`.


### PR DESCRIPTION
there seems to be a typo in the document. It should be: ```examples```
![image](https://github.com/user-attachments/assets/99be01e4-6755-4763-836c-89c1e504f272)