### PR TITLE
Fixed broken URL to Ten Agent in the documentation

### DIFF
--- a/docs/ten_agent/overview.md
+++ b/docs/ten_agent/overview.md
@@ -4,7 +4,7 @@ TEN Agent is a conversational AI agent powered by the TEN, integrating Gemini 2.
 
 ## Links
 
-- [TEN Agent](https://github.com/TEN-framework/ten_agent)
+- [TEN Agent](https://github.com/TEN-framework/TEN-Agent)
 - [TEN Framework](https://github.com/TEN-framework/ten_framework)
 
 ## Architecture


### PR DESCRIPTION
Fixed broken url to Ten Agent in the documentation.
Earlier:
<img width="1755" alt="image" src="https://github.com/user-attachments/assets/b37a1296-b029-405a-b5eb-17c417653799" />

Now:
<img width="1522" alt="image" src="https://github.com/user-attachments/assets/9910fb34-9daa-49f6-850b-d67053c78f8d" />
