### PR TITLE
fix: able to run multiple pytest cases

### DIFF
--- a/packages/core_extensions/default_async_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_async_extension_python/tests/bin/start
@@ -5,6 +5,7 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/ten_packages/system/ten_runtime_python/interface
+export TEN_DISABLE_ADDON_UNREGISTER_AFTER_APP_CLOSE=true
 
 # If the Python app imports some modules that are compiled with a different
 # version of libstdc++ (ex: PyTorch), the Python app may encounter confusing

--- a/packages/core_extensions/default_async_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_async_extension_python/tests/bin/start
@@ -18,4 +18,4 @@ export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/t
 #
 # Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
 
-pytest -s tests/
+pytest tests/ "$@"

--- a/packages/core_extensions/default_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_extension_python/tests/bin/start
@@ -5,6 +5,7 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/ten_packages/system/ten_runtime_python/interface
+export TEN_DISABLE_ADDON_UNREGISTER_AFTER_APP_CLOSE=true
 
 # If the Python app imports some modules that are compiled with a different
 # version of libstdc++ (ex: PyTorch), the Python app may encounter confusing

--- a/packages/core_extensions/default_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_extension_python/tests/bin/start
@@ -18,4 +18,4 @@ export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/t
 #
 # Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
 
-pytest -s tests/
+pytest tests/ "$@"


### PR DESCRIPTION
- allow to run multiple test cases for python extensions      
- let users to customize the `pytest` args for more flexibility