### PR TITLE
fix: enhance tests for python extension template

### DIFF
--- a/packages/core_extensions/default_async_extension_python/extension.py.tent
+++ b/packages/core_extensions/default_async_extension_python/extension.py.tent
@@ -39,7 +39,7 @@ class {{class_name_prefix}}Extension(AsyncExtension):
         # TODO: process cmd
 
         cmd_result = CmdResult.create(StatusCode.OK)
-        ten_env.return_result(cmd_result, cmd)
+        await ten_env.return_result(cmd_result, cmd)
 
     async def on_data(self, ten_env: AsyncTenEnv, data: Data) -> None:
         data_name = data.get_name()

--- a/packages/core_extensions/default_async_extension_python/manifest.json
+++ b/packages/core_extensions/default_async_extension_python/manifest.json
@@ -13,11 +13,12 @@
     "include": [
       "manifest.json",
       "property.json",
-      "BUILD.gn",
       "**.tent",
       "**.py",
       "README.md",
-      "tests/**"
+      "tests/**.py",
+      "tests/**.tent",
+      "tests/bin/start"
     ]
   },
   "api": {}

--- a/packages/core_extensions/default_async_extension_python/manifest.json.tent
+++ b/packages/core_extensions/default_async_extension_python/manifest.json.tent
@@ -13,11 +13,8 @@
     "include": [
       "manifest.json",
       "property.json",
-      "BUILD.gn",
-      "**.tent",
       "**.py",
-      "README.md",
-      "tests/**"
+      "README.md"
     ]
   },
   "api": {}

--- a/packages/core_extensions/default_async_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_async_extension_python/tests/bin/start
@@ -18,4 +18,4 @@ export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/t
 #
 # Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
 
-pytest -s tests/ "$@"
+pytest tests/ "$@"

--- a/packages/core_extensions/default_async_extension_python/tests/test_basic.py
+++ b/packages/core_extensions/default_async_extension_python/tests/test_basic.py
@@ -28,7 +28,7 @@ class ExtensionTesterBasic(ExtensionTester):
         assert result is not None
 
         statusCode = result.get_status_code()
-        print("receive hello_world, status:" + str(statusCode))
+        ten_env.log_debug(f"receive hello_world, status: {statusCode}")
 
         if statusCode == StatusCode.OK:
             ten_env.stop_test()
@@ -36,7 +36,7 @@ class ExtensionTesterBasic(ExtensionTester):
     def on_start(self, ten_env: TenEnvTester) -> None:
         new_cmd = Cmd.create("hello_world")
 
-        print("send hello_world")
+        ten_env.log_debug("send hello_world")
         ten_env.send_cmd(
             new_cmd,
             lambda ten_env, result, error: self.check_hello(
@@ -44,7 +44,7 @@ class ExtensionTesterBasic(ExtensionTester):
             ),
         )
 
-        print("tester on_start_done")
+        ten_env.log_debug("tester on_start_done")
         ten_env.on_start_done()
 
 

--- a/packages/core_extensions/default_async_extension_python/tests/test_basic.py.tent
+++ b/packages/core_extensions/default_async_extension_python/tests/test_basic.py.tent
@@ -1,0 +1,54 @@
+#
+# Copyright © 2025 Agora
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0, with certain conditions.
+# Refer to the "LICENSE" file in the root directory for more information.
+#
+from typing import Optional
+from ten import (
+    ExtensionTester,
+    TenEnvTester,
+    Cmd,
+    CmdResult,
+    StatusCode,
+    TenError,
+)
+
+
+class ExtensionTesterBasic(ExtensionTester):
+    def check_hello(
+        self,
+        ten_env: TenEnvTester,
+        result: Optional[CmdResult],
+        error: Optional[TenError],
+    ):
+        if error is not None:
+            assert False, error.error_message()
+
+        assert result is not None
+
+        statusCode = result.get_status_code()
+        ten_env.log_debug(f"receive hello_world, status: {statusCode}")
+
+        if statusCode == StatusCode.OK:
+            ten_env.stop_test()
+
+    def on_start(self, ten_env: TenEnvTester) -> None:
+        new_cmd = Cmd.create("hello_world")
+
+        ten_env.log_debug("send hello_world")
+        ten_env.send_cmd(
+            new_cmd,
+            lambda ten_env, result, error: self.check_hello(
+                ten_env, result, error
+            ),
+        )
+
+        ten_env.log_debug("tester on_start_done")
+        ten_env.on_start_done()
+
+
+def test_basic():
+    tester = ExtensionTesterBasic()
+    tester.set_test_mode_single("{{package_name}}")
+    tester.run()

--- a/packages/core_extensions/default_extension_python/manifest.json
+++ b/packages/core_extensions/default_extension_python/manifest.json
@@ -13,11 +13,12 @@
     "include": [
       "manifest.json",
       "property.json",
-      "BUILD.gn",
       "**.tent",
       "**.py",
       "README.md",
-      "tests/**"
+      "tests/**.py",
+      "tests/**.tent",
+      "tests/bin/start"
     ]
   },
   "api": {}

--- a/packages/core_extensions/default_extension_python/manifest.json.tent
+++ b/packages/core_extensions/default_extension_python/manifest.json.tent
@@ -13,11 +13,8 @@
     "include": [
       "manifest.json",
       "property.json",
-      "BUILD.gn",
-      "**.tent",
       "**.py",
-      "README.md",
-      "tests/**"
+      "README.md"
     ]
   },
   "api": {}

--- a/packages/core_extensions/default_extension_python/tests/bin/start
+++ b/packages/core_extensions/default_extension_python/tests/bin/start
@@ -18,4 +18,4 @@ export PYTHONPATH=.ten/app/ten_packages/system/ten_runtime_python/lib:.ten/app/t
 #
 # Refer to https://github.com/pytorch/pytorch/issues/102360?from_wecom=1#issuecomment-1708989096
 
-pytest -s tests/ "$@"
+pytest tests/ "$@"

--- a/packages/core_extensions/default_extension_python/tests/test_basic.py
+++ b/packages/core_extensions/default_extension_python/tests/test_basic.py
@@ -28,7 +28,7 @@ class ExtensionTesterBasic(ExtensionTester):
         assert result is not None
 
         statusCode = result.get_status_code()
-        print("receive hello_world, status:" + str(statusCode))
+        ten_env.log_debug(f"receive hello_world, status: {statusCode}")
 
         if statusCode == StatusCode.OK:
             ten_env.stop_test()
@@ -36,7 +36,7 @@ class ExtensionTesterBasic(ExtensionTester):
     def on_start(self, ten_env: TenEnvTester) -> None:
         new_cmd = Cmd.create("hello_world")
 
-        print("send hello_world")
+        ten_env.log_debug("send hello_world")
         ten_env.send_cmd(
             new_cmd,
             lambda ten_env, result, error: self.check_hello(
@@ -44,7 +44,7 @@ class ExtensionTesterBasic(ExtensionTester):
             ),
         )
 
-        print("tester on_start_done")
+        ten_env.log_debug("tester on_start_done")
         ten_env.on_start_done()
 
 

--- a/packages/core_extensions/default_extension_python/tests/test_basic.py.tent
+++ b/packages/core_extensions/default_extension_python/tests/test_basic.py.tent
@@ -1,0 +1,54 @@
+#
+# Copyright © 2025 Agora
+# This file is part of TEN Framework, an open source project.
+# Licensed under the Apache License, Version 2.0, with certain conditions.
+# Refer to the "LICENSE" file in the root directory for more information.
+#
+from typing import Optional
+from ten import (
+    ExtensionTester,
+    TenEnvTester,
+    Cmd,
+    CmdResult,
+    StatusCode,
+    TenError,
+)
+
+
+class ExtensionTesterBasic(ExtensionTester):
+    def check_hello(
+        self,
+        ten_env: TenEnvTester,
+        result: Optional[CmdResult],
+        error: Optional[TenError],
+    ):
+        if error is not None:
+            assert False, error.error_message()
+
+        assert result is not None
+
+        statusCode = result.get_status_code()
+        ten_env.log_debug(f"receive hello_world, status: {statusCode}")
+
+        if statusCode == StatusCode.OK:
+            ten_env.stop_test()
+
+    def on_start(self, ten_env: TenEnvTester) -> None:
+        new_cmd = Cmd.create("hello_world")
+
+        ten_env.log_debug("send hello_world")
+        ten_env.send_cmd(
+            new_cmd,
+            lambda ten_env, result, error: self.check_hello(
+                ten_env, result, error
+            ),
+        )
+
+        ten_env.log_debug("tester on_start_done")
+        ten_env.on_start_done()
+
+
+def test_basic():
+    tester = ExtensionTesterBasic()
+    tester.set_test_mode_single("{{package_name}}")
+    tester.run()


### PR DESCRIPTION
- [x] fixed missed `await`     
- [x] only package necessary files for generated extension       
- [x] leverage ten's log in testing       
- [x] add template for testing       
- [x] remove `-s` to let users control `pytest` args        
