### PR TITLE
feat(fe): refine GH and check update

### DIFF
--- a/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/en-US/common.json
@@ -1,5 +1,6 @@
 {
   "tenFramework": "TEN Framework",
+  "ten": "TEN",
   "header": {
     "title": "Ten Manager",
     "menu": {
@@ -13,8 +14,8 @@
       "about": "About",
       "language": "Language",
       "language.enUS": "English",
-      "language.zhCN": "Simplified Chinese",
-      "language.zhTW": "Traditional Chinese",
+      "language.zhCN": "中文(简体)",
+      "language.zhTW": "中文(繁體)",
       "theme": "Theme",
       "theme.light": "Light",
       "theme.dark": "Dark",
@@ -26,7 +27,8 @@
     "officialSite": "Official site",
     "poweredBy": "Powered by",
     "poweredByTenFramework": "Powered by <0></0>",
-    "github": "GitHub"
+    "github": "GitHub",
+    "tryTENAgent": "Try TEN Agent"
   },
   "action": {
     "edit": "Edit",

--- a/core/src/ten_manager/designer_frontend/public/locales/zh-CN/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/zh-CN/common.json
@@ -1,5 +1,6 @@
 {
   "tenFramework": "TEN 框架",
+  "ten": "TEN",
   "header": {
     "title": "Ten 管理器",
     "menu": {
@@ -13,8 +14,8 @@
       "about": "关于",
       "language": "语言",
       "language.enUS": "English",
-      "language.zhCN": "简体中文",
-      "language.zhTW": "繁体中文",
+      "language.zhCN": "中文(简体)",
+      "language.zhTW": "中文(繁體)",
       "theme": "主题",
       "theme.light": "明亮",
       "theme.dark": "暗黑",
@@ -26,7 +27,8 @@
     "officialSite": "官方网站",
     "poweredBy": "技术支持",
     "poweredByTenFramework": "由 <0></0> 提供支持",
-    "github": "GitHub"
+    "github": "GitHub",
+    "tryTENAgent": "尝试 TEN Agent"
   },
   "action": {
     "edit": "编辑",

--- a/core/src/ten_manager/designer_frontend/public/locales/zh-TW/common.json
+++ b/core/src/ten_manager/designer_frontend/public/locales/zh-TW/common.json
@@ -13,8 +13,8 @@
       "about": "關於",
       "language": "語言",
       "language.enUS": "English",
-      "language.zhCN": "簡體中文",
-      "language.zhTW": "繁體中文",
+      "language.zhCN": "中文(简体)",
+      "language.zhTW": "中文(繁體)",
       "theme": "主題",
       "theme.light": "明亮",
       "theme.dark": "暗黑",
@@ -26,7 +26,8 @@
     "officialSite": "官方網站",
     "poweredBy": "技術支援",
     "poweredByTenFramework": "由 <0></0> 提供支援",
-    "github": "GitHub"
+    "github": "GitHub",
+    "tryTENAgent": "嘗試 TEN Agent"
   },
   "action": {
     "edit": "編輯",

--- a/core/src/ten_manager/designer_frontend/src/App.tsx
+++ b/core/src/ten_manager/designer_frontend/src/App.tsx
@@ -18,7 +18,6 @@ import { useTranslation } from "react-i18next";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import AppBar from "@/components/AppBar/AppBar";
 import FlowCanvas, { type FlowCanvasRef } from "@/flow/FlowCanvas";
-import { useVersion } from "@/api/services/common";
 import {
   getGraphNodes,
   getGraphConnections,
@@ -58,8 +57,6 @@ const App: React.FC = () => {
     "left" | "bottom" | "right"
   >("bottom");
 
-  // Get the version of tman.
-  const { version } = useVersion();
   const { t } = useTranslation();
   const { widgets } = useWidgetStore();
 
@@ -200,7 +197,6 @@ const App: React.FC = () => {
           )}
           <ResizablePanel defaultSize={dockWidgetsMemo.length > 0 ? 60 : 100}>
             <AppBar
-              version={version}
               onAutoLayout={performAutoLayout}
               onOpenExistingGraph={handleOpenExistingGraph}
               onSetBaseDir={handleSetBaseDir}

--- a/core/src/ten_manager/designer_frontend/src/api/endpoints/index.ts
+++ b/core/src/ten_manager/designer_frontend/src/api/endpoints/index.ts
@@ -35,17 +35,19 @@ export const ENDPOINT_COMMON = {
   },
   checkUpdate: {
     [ENDPOINT_METHOD.GET]: {
-      url: `${API_DESIGNER_V1}/check-update`,
+      url: `${API_DESIGNER_V1}/check_update`,
       method: ENDPOINT_METHOD.GET,
       responseSchema: genResSchema<{
-        status: string;
         update_available: boolean;
-        latest_version: string;
+        latest_version: string | null;
+        release_page: string | null;
+        message: string | null;
       }>(
         z.object({
-          status: z.string(),
           update_available: z.boolean(),
-          latest_version: z.string(),
+          latest_version: z.string().nullable(),
+          release_page: z.string().nullable(),
+          message: z.string().nullable(),
         })
       ),
     },

--- a/core/src/ten_manager/designer_frontend/src/api/endpoints/index.ts
+++ b/core/src/ten_manager/designer_frontend/src/api/endpoints/index.ts
@@ -35,7 +35,7 @@ export const ENDPOINT_COMMON = {
   },
   checkUpdate: {
     [ENDPOINT_METHOD.GET]: {
-      url: `${API_DESIGNER_V1}/check_update`,
+      url: `${API_DESIGNER_V1}/check-update`,
       method: ENDPOINT_METHOD.GET,
       responseSchema: genResSchema<{
         update_available: boolean;

--- a/core/src/ten_manager/designer_frontend/src/api/services/common.ts
+++ b/core/src/ten_manager/designer_frontend/src/api/services/common.ts
@@ -50,7 +50,7 @@ export const useCheckUpdate = () => {
     refreshInterval: 0,
   });
   return {
-    data,
+    data: data?.data,
     error,
     isLoading,
   };

--- a/core/src/ten_manager/designer_frontend/src/components/AppBar/AppBar.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/AppBar/AppBar.tsx
@@ -5,7 +5,7 @@
 // Refer to the "LICENSE" file in the root directory for more information.
 //
 import * as React from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 
 import {
   NavigationMenu,
@@ -13,32 +13,26 @@ import {
 } from "@/components/ui/NavigationMenu";
 import { ModeToggle } from "@/components/ModeToggle";
 import { LanguageToggle } from "@/components/LangSwitch";
-import { Badge } from "@/components/ui/Badge";
 import { AppMenu } from "@/components/AppBar/Menu/AppMenu";
 import { EditMenu } from "@/components/AppBar/Menu/EditMenu";
 import { HelpMenu } from "@/components/AppBar/Menu/HelpMenu";
 import { AppStatus } from "@/components/AppBar/AppStatus";
-import { GHStargazersCount } from "@/components/Widget/GH";
+import { GHStargazersCount, GHTryTENAgent } from "@/components/Widget/GH";
+import { Version } from "@/components/AppBar/Version";
 import { cn } from "@/lib/utils";
 import { TEN_FRAMEWORK_GH_OWNER, TEN_FRAMEWORK_GH_REPO } from "@/constants";
 
 interface AppBarProps {
-  // The current version of tman.
-  version?: string;
-
   onOpenExistingGraph: () => void;
   onAutoLayout: () => void;
   onSetBaseDir: (folderPath: string) => void;
 }
 
 const AppBar: React.FC<AppBarProps> = ({
-  version,
   onOpenExistingGraph,
   onAutoLayout,
   onSetBaseDir,
 }) => {
-  const { t } = useTranslation();
-
   const onNavChange = () => {
     setTimeout(() => {
       const triggers = document.querySelectorAll(
@@ -72,10 +66,6 @@ const AppBar: React.FC<AppBarProps> = ({
           />
           <HelpMenu />
         </NavigationMenuList>
-        <GHStargazersCount
-          owner={TEN_FRAMEWORK_GH_OWNER}
-          repo={TEN_FRAMEWORK_GH_REPO}
-        />
       </NavigationMenu>
 
       {/* Middle part is the status bar. */}
@@ -90,22 +80,12 @@ const AppBar: React.FC<AppBarProps> = ({
       <div className="flex items-center gap-1.5">
         <LanguageToggle />
         <ModeToggle />
-        <div
-          className={cn(
-            "text-xs text-muted-foreground flex items-center gap-2 relative"
-          )}
-        >
-          <div>
-            <Trans
-              components={[
-                <PoweredByTenFramework className="font-bold text-foreground" />,
-              ]}
-              t={t}
-              i18nKey="header.poweredByTenFramework"
-            />
-          </div>
-          <Badge variant="secondary">{version}</Badge>
-        </div>
+        <GHStargazersCount
+          owner={TEN_FRAMEWORK_GH_OWNER}
+          repo={TEN_FRAMEWORK_GH_REPO}
+        />
+        <GHTryTENAgent />
+        <Version />
       </div>
     </div>
   );

--- a/core/src/ten_manager/designer_frontend/src/components/AppBar/Version.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/AppBar/Version.tsx
@@ -1,0 +1,42 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+import { ArrowUpIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Badge } from "@/components/ui/Badge";
+import { useVersion, useCheckUpdate } from "@/api/services/common";
+import { cn } from "@/lib/utils";
+import { TEN_FRAMEWORK_RELEASE_URL } from "@/constants";
+
+export function Version() {
+  const { version } = useVersion();
+  const { data: updateData } = useCheckUpdate();
+
+  const { t } = useTranslation("header");
+
+  return (
+    <Badge variant="secondary" className="relative gap-2">
+      <span className="uppercase">{t("ten")}</span>
+      <a
+        href={updateData?.release_page || TEN_FRAMEWORK_RELEASE_URL}
+        target="_blank"
+        className="inline-flex items-center gap-1"
+      >
+        <span className="uppercase"> {version}</span>
+
+        {updateData?.update_available && (
+          <ArrowUpIcon
+            className={cn(
+              "size-3 stroke-3 ",
+              "text-emerald-500 animate-bounce"
+            )}
+          />
+        )}
+      </a>
+    </Badge>
+  );
+}

--- a/core/src/ten_manager/designer_frontend/src/components/Icons/index.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Icons/index.tsx
@@ -1,0 +1,34 @@
+//
+// Copyright © 2025 Agora
+// This file is part of TEN Framework, an open source project.
+// Licensed under the Apache License, Version 2.0, with certain conditions.
+// Refer to the "LICENSE" file in the root directory for more information.
+//
+
+/* eslint-disable max-len */
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const GHIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  const { className, ...rest } = props;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 98 96"
+      className={cn(
+        "[&_path]:fill-[#24292f] dark:[&_path]:fill-[#fff]",
+        className
+      )}
+      {...rest}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+        // fill="#24292f"
+      />
+    </svg>
+  );
+};

--- a/core/src/ten_manager/designer_frontend/src/components/Widget/GH.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Widget/GH.tsx
@@ -4,12 +4,22 @@
 // Licensed under the Apache License, Version 2.0, with certain conditions.
 // Refer to the "LICENSE" file in the root directory for more information.
 //
-import { GithubIcon } from "lucide-react";
+import * as React from "react";
+import { StarIcon, BotIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
-import { badgeVariants } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/Tooltip";
+import { GHIcon } from "@/components/Icons";
 import { cn } from "@/lib/utils";
 import { useGHRepository } from "@/api/services/github";
 import { formatNumberWithCommas } from "@/lib/utils";
+import { TEN_AGENT_URL } from "@/constants";
 
 export function GHStargazersCount(props: {
   owner: string;
@@ -20,38 +30,58 @@ export function GHStargazersCount(props: {
 
   const { repository, error, isLoading } = useGHRepository(owner, repo);
 
-  if (isLoading || error) {
-    return null;
-  }
+  const shouldFallbackMemo = React.useMemo(() => {
+    return isLoading || error || !repository?.stargazers_count;
+  }, [isLoading, error, repository]);
 
   return (
-    <a
-      href={`https://github.com/${owner}/${repo}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        badgeVariants({ variant: "outline" }),
-        "p-0 mx-1",
-        className
-      )}
-    >
-      <div
-        className={cn(
-          badgeVariants({ variant: "secondary" }),
-          "h-[22px] rounded-r-none px-2"
-        )}
+    <Button asChild variant="ghost" size="sm">
+      <a
+        href={`https://github.com/${owner}/${repo}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn("flex items-center gap-1.5", "text-sm", className)}
       >
-        <GithubIcon className="size-4" />
-        {/* <span>Star</span> */}
-      </div>
-      <span
-        className={cn(
-          badgeVariants({ variant: "secondary" }),
-          "bg-transparent rounded-l-none hover:bg-transparent"
+        {shouldFallbackMemo ? (
+          <GHIcon className="size-4" />
+        ) : (
+          <>
+            <StarIcon className="size-4 text-yellow-500" />
+            <span>
+              {formatNumberWithCommas(repository?.stargazers_count as number)}
+            </span>
+          </>
         )}
-      >
-        {formatNumberWithCommas(repository?.stargazers_count || 0)}
-      </span>
-    </a>
+      </a>
+    </Button>
+  );
+}
+
+export function GHTryTENAgent(props: { className?: string }) {
+  const { className } = props;
+
+  const { t } = useTranslation();
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button asChild variant="ghost" size="sm">
+            <a
+              href={TEN_AGENT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn("flex items-center gap-1.5", "text-sm", className)}
+            >
+              <BotIcon className="size-4" />
+              <span className="sr-only">{t("header.tryTENAgent")}</span>
+            </a>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{t("header.tryTENAgent")}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/core/src/ten_manager/designer_frontend/src/components/Widget/GH.tsx
+++ b/core/src/ten_manager/designer_frontend/src/components/Widget/GH.tsx
@@ -66,7 +66,7 @@ export function GHTryTENAgent(props: { className?: string }) {
     <TooltipProvider delayDuration={100}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button asChild variant="ghost" size="sm">
+          <Button asChild variant="ghost" size="icon">
             <a
               href={TEN_AGENT_URL}
               target="_blank"

--- a/core/src/ten_manager/designer_frontend/src/constants/index.ts
+++ b/core/src/ten_manager/designer_frontend/src/constants/index.ts
@@ -6,6 +6,11 @@
 //
 export const TEN_FRAMEWORK_URL = "https://www.theten.ai/";
 export const TEN_FRAMEWORK_GITHUB_URL = "https://github.com/TEN-framework/";
+export const TEN_FRAMEWORK_RELEASE_URL =
+  "https://github.com/TEN-framework/ten_framework/releases";
+export const TEN_AGENT_URL = "https://agent.theten.ai/";
+export const TEN_AGENT_GITHUB_URL =
+  "https://github.com/TEN-framework/TEN-Agent";
 
 export const TEN_DEFAULT_APP_RUN_SCRIPT = "start";
 

--- a/core/src/ten_manager/src/designer/mod.rs
+++ b/core/src/ten_manager/src/designer/mod.rs
@@ -48,7 +48,7 @@ pub fn configure_routes(
             .app_data(state.clone())
             .route("/version", web::get().to(version::get_version))
             .route(
-                "/check_update",
+                "/check-update",
                 web::get().to(version::check_update_endpoint),
             )
             .route(


### PR DESCRIPTION
default: `star count with link`, `ten-agent link`, `version with link`

<img width="345" alt="image" src="https://github.com/user-attachments/assets/69551220-331a-4ad4-a102-5f4c2d8114cc" />

missing GH stars data (no network or API rate limitation): `star count with link` -> `fallback to GH icon and link`

<img width="336" alt="image" src="https://github.com/user-attachments/assets/b34c35d0-6695-43a7-ab87-e87d13fd7f2c" />

outdate version: `version with link` -> `version with remider and link`

<img width="361" alt="image" src="https://github.com/user-attachments/assets/1a33d084-4ae6-4b1e-8882-df1b02af5867" />

